### PR TITLE
Enable test_float, test_setjmp, AES-XTS test cases and Disable xtest 1021.3

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1707,12 +1707,12 @@ static void xtest_tee_test_1021(ADBG_Case_t *c)
 	test_panic_ca_to_ta(c, &sims_test_ta_uuid, false);
 	Do_ADBG_EndSubCase(c, "Single Instance Multi Sessions");
 
+	/* TODO:Will enable it for OP-TEE x86_64 later */
+#if 0
 	Do_ADBG_BeginSubCase(c, "Single Instance Multi Sessions Keep Alive");
 	test_panic_ca_to_ta(c, &sims_keepalive_test_ta_uuid, false);
 	Do_ADBG_EndSubCase(c, "Single Instance Multi Sessions Keep Alive");
 
-	/* TODO:Will enable it for OP-TEE x86_64 later */
-#if 0
 	Do_ADBG_BeginSubCase(c, "Multi Sessions TA to TA");
 	test_panic_ta_to_ta(c, &sims_test_ta_uuid,
 			    &sims_keepalive_test_ta_uuid);

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -2308,13 +2308,10 @@ static const struct xtest_ciph_case ciph_cases[] = {
 	XTEST_CIPH_CASE_AES_XTS(vect12, 7),
 	XTEST_CIPH_CASE_AES_XTS(vect13, 3),
 	XTEST_CIPH_CASE_AES_XTS(vect14, 2),
-	/* TODO: will fix invalid op issue for OP-TEE x86_64 */
-#if 0
 	XTEST_CIPH_CASE_AES_XTS(vect15, 0),
 	XTEST_CIPH_CASE_AES_XTS(vect16, 9),
 	XTEST_CIPH_CASE_AES_XTS(vect17, 6),
 	XTEST_CIPH_CASE_AES_XTS(vect18, 8),
-#endif
 	XTEST_CIPH_CASE_AES_XTS(vect19, 23),
 };
 

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -576,8 +576,6 @@ static TEE_Result test_time(void)
 	return TEE_SUCCESS;
 }
 
-/* TODO: will enable float test for x86 */
-#if 0
 #ifdef CFG_TA_FLOAT_SUPPORT
 static bool my_dcmpeq(double v1, double v2, double prec)
 {
@@ -661,10 +659,7 @@ static TEE_Result test_float(void)
 	return TEE_SUCCESS;
 }
 #endif /*CFG_TA_FLOAT_SUPPORT*/
-#endif
 
-/* TODO: will enable jmp test for x86 */
-#if 0
 static __noinline void call_longjmp(jmp_buf env)
 {
 	DMSG("Calling longjmp");
@@ -684,7 +679,6 @@ static TEE_Result test_setjmp(void)
 		return TEE_ERROR_GENERIC;
 	}
 }
-#endif
 
 TEE_Result ta_entry_basic(uint32_t param_types, TEE_Param params[4])
 {
@@ -708,14 +702,13 @@ TEE_Result ta_entry_basic(uint32_t param_types, TEE_Param params[4])
 	if (res != TEE_SUCCESS)
 		return res;
 
-	/* TODO: will enable these when support is available */
-	/*res = test_float();
+	res = test_float();
 	if (res != TEE_SUCCESS)
 		return res;
 
 	res = test_setjmp();
 	if (res != TEE_SUCCESS)
-		return res;*/
+		return res;
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
1 : The relevant features have been added in OP-TEE OS, 
     so enable these test cases in xtest
2 : Xtest 1021.3 is dependent on 1021.4. 
     Because 1021.4 is disabled for now, disable 1021.3 as well.
     Both of them will be enabled later when optee_os code supports them
