### PR TITLE
regression 8102, 8103: change myasprintf implementation

### DIFF
--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -54,6 +54,7 @@ static int __printf(2, 3) myasprintf(char **strp, const char *fmt, ...)
 
 	va_start(ap, fmt);
 	rc = vsnprintf(str, rc, fmt, ap);
+	va_end(ap);
 	if (rc <= 0)
 		goto out;
 
@@ -63,14 +64,15 @@ static int __printf(2, 3) myasprintf(char **strp, const char *fmt, ...)
 		goto out;
 	}
 
+	va_start(ap, fmt);
 	rc = vsnprintf(str, rc, fmt, ap);
+	va_end(ap);
 	if (rc <= 0)
 		free(str);
 	else
 		*strp = str;
 
 out:
-	va_end(ap);
 	return rc;
 }
 


### PR DESCRIPTION
va_list ap is undefined after a call to vsnprintf, so need
to put va_start and va_end before and after every vsnprintf.
Otherwise, the content of str buffer may be messed up.

Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Jerome Forissier <jerome@forissier.org>
Signed-off-by: Jingdong Lu <jingdong.lu@intel.com>