### PR TITLE
Fix link error when compiling in Android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -35,10 +35,6 @@ srcs += regression_2000.c \
 	rand_stream.c
 endif
 
-ifeq ($(CFG_SECSTOR_TA_MGMT_PTA),y)
-srcs += install_ta.c
-endif
-
 srcs +=	adbg/src/adbg_case.c \
 	adbg/src/adbg_enum.c \
 	adbg/src/adbg_expect.c \
@@ -60,6 +56,10 @@ srcs +=	adbg/src/adbg_case.c \
 	xtest_main.c \
 	xtest_test.c \
 	xtest_uuid_helpers.c
+
+# Workaround for compiling in Android
+# Assume CFG_SECSTOR_TA_MGMT_PTA always enabled on x86 
+srcs += install_ta.c
 
 ifeq ($(CFG_SECURE_DATA_PATH),y)
 srcs += sdp_basic.c


### PR DESCRIPTION
There will be link error "undefined symbol: install_ta_runner_cmd_parser" when compiling in Android. So make this workaround to fix this issue.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
